### PR TITLE
Board render

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -104,6 +104,7 @@ class Board
   def render(reveal = nil)
     keys = @cells.keys
     coordinate_groups = keys.each_slice(4).to_a
+    p '  1 2 3 4'
     coordinate_groups.each do |group|
       output = group.map do |coordinate|
         @cells[coordinate].render

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -1,5 +1,3 @@
-require 'pry'
-
 class Board
   attr_accessor :cells
 
@@ -100,6 +98,17 @@ class Board
     keys = coordinates
     keys.each do |key|
       @cells[key].place_ship(ship)
+    end
+  end
+
+  def render(reveal = nil)
+    keys = @cells.keys
+    coordinate_groups = keys.each_slice(4).to_a
+    coordinate_groups.each do |group|
+      output = group.map do |coordinate|
+        @cells[coordinate].render
+      end
+      p output.join(' ').prepend(group[0].byteslice(0) + ' ')
     end
   end
 end

--- a/test/board_test.rb
+++ b/test/board_test.rb
@@ -99,6 +99,10 @@ class BoardTest < Minitest::Test
   def test_board_render_produces_output
     board = Board.new
 
-    assert board.render
+    assert_output "  1 2 3 4", board.render
+                  "A . . . ."
+                  "B . . . ."
+                  "C . . . ."
+                  "D . . . ."
   end
 end

--- a/test/board_test.rb
+++ b/test/board_test.rb
@@ -95,4 +95,10 @@ class BoardTest < Minitest::Test
     assert_equal false, board.valid_placement?(submarine, ['A1', 'B1'])
     assert_equal false, board.valid_placement?(cruiser, ['A2', 'B2', 'C2'])
   end
+
+  def test_board_render_produces_output
+    board = Board.new
+
+    assert board.render
+  end
 end

--- a/test/cell_test.rb
+++ b/test/cell_test.rb
@@ -4,6 +4,7 @@ require 'minitest/autorun'
 require 'minitest/pride'
 require './lib/ship'
 require './lib/cell'
+require 'pry'
 
 class CellTest < Minitest::Test
 
@@ -14,9 +15,8 @@ class CellTest < Minitest::Test
 
   def test_cell_is_empty
     cell = Cell.new("B4")
+
     assert_equal true, cell.empty?
-    cell.ship = true
-    assert_equal false, cell.empty?
   end
 
   def test_ship_can_be_placed_in_cell


### PR DESCRIPTION
## Board Render

Added `.render` method to Board class to produce desired board output states.

* `.render` is built to be infinitely scalable for any amount of rows
* `.render` displays the correct output for columns 1-4, but the logic needs to be updated to scale for infinite columns
* We are currently working on building tests for multiple string outputs in one test 