### PR TITLE
Remove coordinate sort to produce valid coordinates

### DIFF
--- a/lib/turn.rb
+++ b/lib/turn.rb
@@ -68,7 +68,6 @@ class Turn
   end
 
   def validate_human_input(ship, coordinates)
-    coordinates.sort!
     if coordinates.length != ship.length
       puts 'Those are invalid coordinates. Please try again.'
     elsif coordinates.all? { |cell| @user.board.cells.include?(cell) } == false


### PR DESCRIPTION
* Removed `coordinates.sort` from `validate_human_input`
  * This will prevent coordinates entered as C1, B1, D1 from being valid